### PR TITLE
run full auto-merge search asynchronously

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -96,8 +96,8 @@ void githubHook(HTTPServerRequest req, HTTPServerResponse res)
         {
             if (lastFullPRCheck + timeBetweenFullPRChecks < Clock.currTime)
             {
-                searchForAutoMergePrs(repoSlug);
                 lastFullPRCheck = Clock.currTime();
+                runTaskHelper(toDelegate(&searchForAutoMergePrs), repoSlug);
             }
         }
         return res.writeBody("handled");


### PR DESCRIPTION
- and always debounce last check time (to avoid busy polling on failure)