### PR TITLE
Provide a default message for squash commits

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -370,7 +370,10 @@ Json[] tryMerge(in ref PullRequest pr, LabelInfo labelInfo)
         reqInput["merge_method"] = "merge";
 
     if (labelInfo.hasAutoMergeSquash)
+    {
         reqInput["merge_method"] = "squash";
+        reqInput["commit_message"] = "%s (#%d)".format(commits[0]["commit"]["message"].get!string, pr.number);
+    }
 
     auto prUrl = "%s/repos/%s/pulls/%d/merge".format(githubAPIURL, pr.repoSlug, pr.number);
     ghSendRequest((scope req){

--- a/test/labels.d
+++ b/test/labels.d
@@ -65,6 +65,26 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res) {
             assert(req.json["sha"] == "d2c7d3761b73405ee39da3fd7fe5030dee35a39e");
             assert(req.json["merge_method"] == "squash");
+            assert(req.json["commit_message"] ==
+`Issue 8573 - A simpler Phobos function that returns the index of the mix or max item
+
+Issue 8573 - A simpler Phobos function that returns the index of the mix or max item
+
+added some review fixes
+
+fixed an issue with a mutable variable
+
+Applied review feedback
+
+Renamed functions to minIndex and maxIndex + used sizediff_t for return value type
+
+Updated function so that it works optimally even for lazy ranges and algorithms
+
+Reverted to having only copyable elements in ranges
+
+Added more unittests; implemented an array path; fixed documentation
+
+Squashed commits (#4921)`);
             res.statusCode = 200;
             res.writeVoidBody;
         }

--- a/test/status.d
+++ b/test/status.d
@@ -98,6 +98,7 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.json["sha"] == "d6fc98058b637f9a558206847e6d7057ab9fb3de");
             assert(req.json["merge_method"] == "squash");
+            assert(req.json["commit_message"] == "taking address of local means it cannot be 'scope' later (#6328)");
             res.statusCode = 200;
             res.writeVoidBody;
         }


### PR DESCRIPTION
The idea is to use only the first commit message if squashing has been selected to avoid such long commit messages like:

https://github.com/dlang-bots/dlang-bot/commit/af8f98dcf00f26a5ae5d34268718d54aac0335a0

![image](https://cloud.githubusercontent.com/assets/4370550/21330668/ddf49ba4-c63e-11e6-9503-16192d08cdcf.png)
