### PR TITLE
Add bugfix label

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -169,6 +169,7 @@ void githubHook(HTTPServerRequest req, HTTPServerResponse res)
 
 void handlePR(string action, PullRequest pr)
 {
+    import std.algorithm : any;
     import vibe.core.core : setTimer;
 
     Json[] commits;
@@ -197,7 +198,7 @@ void handlePR(string action, PullRequest pr)
 
     pr.updateGithubComment(comment, action, refs, descs);
 
-    if (refs.length > 0 && comment.body_.length == 0)
+    if (refs.any!(r => r.fixed) && comment.body_.length == 0)
         pr.addLabels(["Bug fix"]);
 
     if (runTrello)

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -197,6 +197,9 @@ void handlePR(string action, PullRequest pr)
 
     pr.updateGithubComment(comment, action, refs, descs);
 
+    if (refs.length > 0 && comment.body_.length == 0)
+        pr.addLabels(["Bug fix"]);
+
     if (runTrello)
         updateTrelloCard(action, pr.htmlURL, refs, descs);
 

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -193,7 +193,9 @@ void handlePR(string action, PullRequest pr)
     auto refs = getIssueRefs(commits);
 
     auto descs = getDescriptions(refs);
-    updateGithubComment(action, refs, descs, pr.commentsURL);
+    auto comment = pr.getBotComment;
+
+    pr.updateGithubComment(comment, action, refs, descs);
 
     if (runTrello)
         updateTrelloCard(action, pr.htmlURL, refs, descs);

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -237,6 +237,13 @@ void checkAndRemoveMergeLabels(Json[] labels, in ref PullRequest pr)
         .each!(l => pr.removeLabel(l));
 }
 
+void addLabels(in ref PullRequest pr, string[] labels)
+{
+    auto labelUrl = "%s/repos/%s/issues/%d/labels"
+            .format(githubAPIURL, pr.repoSlug, pr.number);
+    ghSendRequest(HTTPMethod.POST, labelUrl, labels);
+}
+
 void removeLabel(in ref PullRequest pr, string label)
 {
     auto labelUrl = "%s/repos/%s/issues/%d/labels/%s"

--- a/test/comments.d
+++ b/test/comments.d
@@ -2,6 +2,7 @@ import utils;
 
 import std.format : format;
 
+// existing comment
 unittest
 {
     setAPIExpectations(
@@ -26,7 +27,7 @@ unittest
     postGitHubHook("dlang_phobos_synchronize_4921.json");
 }
 
-// no existing dlang bot comment -> create comment
+// no existing dlang bot comment -> create comment and add bug fix label
 unittest
 {
     setAPIExpectations(
@@ -36,6 +37,13 @@ unittest
             j = Json.emptyArray;
         },
         "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc",
+        // action: add bug fix label
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            assert(req.method == HTTPMethod.POST);
+            assert(req.json[0].get!string == "Bug fix");
+            res.writeVoidBody;
+        },
         "/github/repos/dlang/phobos/issues/4921/comments",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.POST);

--- a/test/comments.d
+++ b/test/comments.d
@@ -37,13 +37,7 @@ unittest
             j = Json.emptyArray;
         },
         "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc",
-        // action: add bug fix label
-        "/github/repos/dlang/phobos/issues/4921/labels",
-        (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            assert(req.method == HTTPMethod.POST);
-            assert(req.json[0].get!string == "Bug fix");
-            res.writeVoidBody;
-        },
+        // no bug fix label, since Issues are only referenced but not fixed according to commit messages
         "/github/repos/dlang/phobos/issues/4921/comments",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.POST);

--- a/test/trello.d
+++ b/test/trello.d
@@ -42,7 +42,7 @@ unittest
     postTrelloHook("active_issue_16794.json");
 }
 
-// update existing dlang bot comment with related GH PRs
+// no existing dlang bot comment -> create comment
 unittest
 {
     setAPIExpectations(
@@ -50,6 +50,13 @@ unittest
         "/github/repos/dlang/dmd/issues/6359/comments",
         "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc",
         "/github/repos/dlang/dmd/issues/6359/comments",
+        // action: add bug fix label
+        "/github/repos/dlang/dmd/issues/6359/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            assert(req.method == HTTPMethod.POST);
+            assert(req.json[0].get!string == "Bug fix");
+            res.writeVoidBody;
+        },
         "/trello/1/search?query=name:%22Issue%2016794%22&"~trelloAuth,
         "/trello/1/cards/583f517a333add7c28e0cec7/actions?filter=commentCard&"~trelloAuth,
         "/trello/1/cards/583f517a333add7c28e0cec7/actions/583f517b91413ef81f1f9d34/comments?"~trelloAuth,
@@ -78,6 +85,13 @@ unittest
         "/github/repos/dlang/dmd/issues/6359/comments",
         "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc",
         "/github/repos/dlang/dmd/issues/6359/comments",
+        // action: add bug fix label
+        "/github/repos/dlang/dmd/issues/6359/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            assert(req.method == HTTPMethod.POST);
+            assert(req.json[0].get!string == "Bug fix");
+            res.writeVoidBody;
+        },
         "/trello/1/search?query=name:%22Issue%2016794%22&"~trelloAuth,
         "/trello/1/cards/583f517a333add7c28e0cec7/actions?filter=commentCard&"~trelloAuth,
         (ref Json j) { j = Json.emptyArray; },

--- a/test/utils.d
+++ b/test/utils.d
@@ -191,10 +191,13 @@ void setAPIExpectations(Args...)(Args args)
 }
 
 void postGitHubHook(string payload, string eventType = "pull_request",
-    void delegate(ref Json j, scope HTTPClientRequest req) postprocess = null)
+    void delegate(ref Json j, scope HTTPClientRequest req) postprocess = null,
+    int line = __LINE__, string file = __FILE__)
 {
     import std.file : readText;
     import std.path : buildPath;
+
+    logInfo("Starting test in %s:%d with payload: %s", file, line, payload);
 
     payload = hookDir.buildPath("github", payload);
 
@@ -228,13 +231,16 @@ void postGitHubHook(string payload, string eventType = "pull_request",
 }
 
 void postTrelloHook(string payload,
-    void delegate(ref Json j, scope HTTPClientRequest req) postprocess = null)
+    void delegate(ref Json j, scope HTTPClientRequest req) postprocess = null,
+    int line = __LINE__, string file = __FILE__)
 {
     import std.file : readText;
     import std.path : buildPath;
     import dlangbot.trello : getSignature;
 
     payload = hookDir.buildPath("trello", payload);
+
+    logInfo("Starting test in %s:%d with payload: %s", file, line, payload);
 
     auto req = requestHTTP(trelloTestHookURL, (scope req) {
         req.method = HTTPMethod.POST;


### PR DESCRIPTION
The idea is to label all bug fixes, s.t. reviewers can filter for them easier. This is often done atm manually.
One good use case is to search for bug fixes prior to the end of the merge window / new releases.