### PR TITLE
Fix #49 - set auto-merge PRs on the priority queue at the Auto-Tester

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -3,6 +3,7 @@ description "dlang-bot for automated bugzilla, github, and trello references"
 copyright "Copyright © 2015, Martin Nowak"
 authors "Martin Nowak"
 dependency "vibe-d" version="~>0.7.30"
+dependency "requests" version="~>0.4.0"
 configuration "default" {
 	versions "VibeDefaultMain"
 	targetType "executable"
@@ -13,3 +14,4 @@ configuration "unittest" {
 	importPaths "source" "test"
 	stringImportPaths "views"
 }
+subConfiguration "requests" "vibed"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -6,6 +6,7 @@
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.8",
 		"openssl": "1.1.5+1.0.1g",
+		"requests": "0.4.0",
 		"vibe-d": "0.7.30"
 	}
 }

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -7,6 +7,7 @@ public import dlangbot.bugzilla : bugzillaURL;
 public import dlangbot.github   : githubAPIURL, githubAuth, hookSecret;
 public import dlangbot.travis   : travisAPIURL;
 public import dlangbot.trello   : trelloAPIURL, trelloAuth, trelloSecret;
+public import dlangbot.autotester : ghAutoTesterLogin, ghAutoTesterPassword;
 
 import std.datetime : Clock, Duration, minutes, seconds, SysTime;
 
@@ -42,6 +43,8 @@ shared static this()
     trelloAuth = "key="~environment["TRELLO_KEY"]~"&token="~environment["TRELLO_TOKEN"];
     hookSecret = environment["GH_HOOK_SECRET"];
     travisAuth = "token " ~ environment["TRAVIS_TOKEN"];
+    ghAutoTesterLogin = environment["GH_AUTO_TESTER_LOGIN"];
+    ghAutoTesterPassword = environment["GH_AUTO_TESTER_PASSWORD"];
 
     // workaround for stupid openssl.conf on Heroku
     if (environment.get("DYNO") !is null)

--- a/source/dlangbot/autotester.d
+++ b/source/dlangbot/autotester.d
@@ -1,0 +1,85 @@
+module dlangbot.autotester;
+
+string ghAutoTesterLogin, ghAutoTesterPassword;
+
+/**
+Sends an auto-merge command to the auto-tester.
+This is an experimental method that depends on scraping the API.
+Moreover it's only supported for dlang/{dmd,druntime,phobos}
+*/
+void setAutoMerge(string repoSlug, ulong pullId)
+{
+    import requests : queryParams, Request, Response;
+    import std.conv : to;
+    import std.exception : enforce;
+    import std.format : format;
+    import std.regex : matchFirst, regex;
+    import vibe.core.log : logDebug;
+
+    // temporarily not tested
+    version(unittest){} else
+    try {
+
+    Request rq = Request();
+    Response rs;
+
+    int repoId;
+    switch (repoSlug) {
+        case "dlang/dmd":
+            repoId = 1; break;
+        case "dlang/druntime":
+            repoId = 2; break;
+        case "dlang/phobos":
+            repoId = 3; break;
+        default:
+            logDebug("repoSlug: %s isn't supported by the auto-tester", repoSlug);
+            return;
+    }
+
+    logDebug("auto-tester: starting request (slug=%s,pull=%d)", repoSlug, pullId);
+
+    // login to github
+    {
+        auto re = regex(`name="authenticity_token".*value="(.*)"`);
+        string url = "https://github.com/login/oauth/authorize?scope=public_repo&response_type=code&client_id=efb9cf46977efe7abd51&state=index.ghtml|";
+        rs = rq.get(url);
+
+        auto githubCsrfToken = rs.responseBody.to!string.matchFirst(re);
+        enforce(!githubCsrfToken.empty, "Couldn't find CSFR token");
+        rs = rq.post("https://github.com/session", queryParams(
+            "authenticity_token", githubCsrfToken[1],
+            "login", ghAutoTesterLogin,
+            "password", ghAutoTesterPassword,
+            "commit", "Sign in"
+        ));
+        enforce(rs.code == 200);
+    }
+
+    logDebug("auto-tester: logged into github (slug=%s,pull=%d)", repoSlug, pullId);
+
+    string autoMergeAPI;
+    // request CSFR from auto-tester
+    {
+        auto url = "https://auto-tester.puremagic.com/pull-history.ghtml?projectid=1&repoid=%d&pullid=%d"
+                   .format(repoId, pullId);
+        rs = rq.get(url);
+        enforce(rs.code == 200);
+
+        auto autoTesterRe = regex(`<td>(.*) – <a href="(addv2\/toggle_auto_merge.*)">Toggle<\/a><\/td>`);
+        auto autoTesterStatus = rs.responseBody.to!string.matchFirst(autoTesterRe);
+        enforce(!autoTesterStatus.empty, "Couldn't find CSFR token");
+
+        // skip if already toggled
+        if (autoTesterStatus[1] == "Yes")
+            return;
+
+        autoMergeAPI = "https://auto-tester.puremagic.com/" ~ autoTesterStatus[2];
+    }
+
+    logDebug("auto-tester: sending auto-merge (slug=%s,pull=%d)", repoSlug, pullId);
+    rq.get(autoMergeAPI);
+
+    } catch(Exception e) {
+        logDebug("auto-tester: failed to sending auto-merge (slug=%s,pull=%d): %s", repoSlug, pullId, e.msg);
+    }
+}

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -267,6 +267,8 @@ Json[] getIssuesForLabel(string repoSlug, string label)
 
 void searchForAutoMergePrs(string repoSlug)
 {
+    import dlangbot.autotester : setAutoMerge;
+
     // the GitHub API doesn't allow a logical OR
     auto issues = getIssuesForLabel(repoSlug, "auto-merge").chain(getIssuesForLabel(repoSlug, "auto-merge-squash"));
     issues.sort!((a, b) => a["number"].get!int < b["number"].get!int);
@@ -282,8 +284,9 @@ void searchForAutoMergePrs(string repoSlug)
         pr.state = PullRequest.State.open;
         pr.title = issue["title"].get!string;
         if (auto method = autoMergeMethod(issue["labels"][]))
+        {
             pr.tryMerge(method);
+            setAutoMerge(repoSlug, prNumber);
+        }
     }
 }
-
-

--- a/test/utils.d
+++ b/test/utils.d
@@ -40,6 +40,9 @@ shared static this()
     ghTestHookURL = testServerURL ~ "/github_hook";
     trelloTestHookURL = testServerURL ~ "/trello_hook";
 
+    ghAutoTesterLogin = "auto-tester-login";
+    ghAutoTesterPassword = "auto-tester-pw";
+
     import vibe.core.log;
     setLogLevel(LogLevel.info);
 


### PR DESCRIPTION
As there is no API for the `auto-tester`, here's a proposal to login as user, send the AutoMerge command to the `auto-tester` and thus prioritize the PR.
However, this requires one to be logged in at GitHub, so this PR first logs in at Github and then via OAuth at the `auto-tester`. As for both GitHub and the auto-tester CSFR protection exists, the authenticity tokens need to scraped from the response. For convenience (and as Vibe.d doesn't handle client-side cookies), I used the excellent [requests](https://github.com/ikod/dlang-requests) library.

The biggest downside to this approach is that it requires the "password" of the dlang-bot to be set as Heroku environment variable, but I don't know of any other way to do so without.

The following needs to be done as well:

- login with `dlang-bot` at the auto-tester and approve the OAuth confirmation dialog
- approve `dlang-bot` for the auto-tester (requires to make a dummy PR, so that it can be approved)
- optionally once this is working: disable GH API merge at the `auto-tester`, s.t. it doesn't conflict with the dlang-bot (for example a merge triggered by the auto-tester wouldn't include the "merged-on-behalf-of" comment)

As this is experimental (and a bit hard to test without messing with real PRs), I set the entire method to "soft-fail".

CC @braddr