### PR TITLE
Remove 'needs rebase' and 'needs work' on new push

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -181,7 +181,9 @@ void handlePR(string action, PullRequest pr)
             return;
         if (action == "synchronize")
         {
-            checkAndRemoveMergeLabels(labelsAndCommits.labels, pr);
+            enum toRemoveLabels = ["auto-merge", "auto-merge-squash",
+                                   "needs rebase", "needs work"];
+            checkAndRemoveLabels(labelsAndCommits.labels, pr, toRemoveLabels);
             if (labelsAndCommits.commits !is null)
                 commits = labelsAndCommits.commits;
         }

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -229,11 +229,11 @@ Json[] tryMerge(in ref PullRequest pr, MergeMethod method)
     return commits;
 }
 
-void checkAndRemoveMergeLabels(Json[] labels, in ref PullRequest pr)
+void checkAndRemoveLabels(Json[] labels, in ref PullRequest pr, in string[] toRemoveLabels)
 {
     labels
         .map!(l => l["name"].get!string)
-        .filter!(n => n.startsWith("auto-merge"))
+        .filter!(n => toRemoveLabels.canFind(n))
         .each!(l => pr.removeLabel(l));
 }
 


### PR DESCRIPTION
On "needs work" and "needs rebase" are commonly used to mark an PR as "inactive" (aka depending on user interaction):

https://github.com/dlang/phobos/pulls?q=is%3Aopen+is%3Apr+label%3A%22needs+rebase%22
https://github.com/dlang/phobos/pulls?q=is%3Aopen+is%3Apr+label%3A%22needs+work%22

Thus as a simple first step, this will remove these labels as well when they are existent.

Small gotchas
------------------

- AFAIK DMD and Druntime use different labels atm (e.g. DMD has only "Needs Work")
- I think a new push usually displays a contributor interaction and it can be assumed that the required work was done and the PR can go back into the review queue.