### PR TITLE
Add link to Regex101

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Using this syntax is also very important because for the changelog generation, t
 git history will be used. Thus _only_ if the Dlang-Bot has detected an issue
 and commented on your PR it can become part of the changelog.
 
+In doubt, you can use e.g. [Regex101](https://regex101.com/r/aI0Rp6/2) to validate your commit message.
+
 ### Nerdy details
 
 - one can mention multiple issues in one commit and/or multiple commits


### PR DESCRIPTION
If someone doesn't want to test a regex bit git force-pushing, this is a useful website. The link opens the used RegEx on Regex101.