### PR TITLE
Fix #53 - recognize common attributes in the PR title

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -152,7 +152,7 @@ void githubHook(HTTPServerRequest req, HTTPServerResponse res)
             if (json["pull_request"]["merged"].get!bool)
                 action = "merged";
             goto case;
-        case "opened", "reopened", "synchronize", "labeled":
+        case "opened", "reopened", "synchronize", "labeled", "edited":
 
             auto pullRequest = json["pull_request"].deserializeJson!PullRequest;
             runTaskHelper(toDelegate(&handlePR), action, pullRequest);
@@ -186,6 +186,9 @@ void handlePR(string action, PullRequest pr)
                 commits = labelsAndCommits.commits;
         }
     }
+
+    if (action == "opened" || action == "edited")
+        checkTitleForLabels(pr);
 
     // we only query the commits once
     if (commits is null)

--- a/test/labels.d
+++ b/test/labels.d
@@ -86,3 +86,43 @@ unittest
         }
     );
 }
+
+// test whether users can label their PR via the title
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/dmd/pulls/6359/commits", (ref Json json) {
+            json = Json.emptyArray;
+        },
+        "/github/repos/dlang/dmd/issues/6359/comments",
+        "/github/repos/dlang/dmd/issues/6359/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res) {
+            assert(req.method == HTTPMethod.POST);
+            assert(req.json.deserializeJson!(string[]) == ["trivial"]);
+            res.writeVoidBody;
+        }
+    );
+
+    postGitHubHook("dlang_dmd_open_6359.json", "pull_request",
+        (ref Json j, scope HTTPClientRequest req){
+            j["pull_request"]["title"] = "[Trivial] foo bar";
+        }
+    );
+}
+
+// test that not only a selection of labels is accepted
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/dmd/pulls/6359/commits", (ref Json json) {
+            json = Json.emptyArray;
+        },
+        "/github/repos/dlang/dmd/issues/6359/comments",
+    );
+
+    postGitHubHook("dlang_dmd_open_6359.json", "pull_request",
+        (ref Json j, scope HTTPClientRequest req){
+            j["pull_request"]["title"] = "[auto-merge] foo bar";
+        }
+    );
+}

--- a/test/utils.d
+++ b/test/utils.d
@@ -9,7 +9,7 @@ public import vibe.http.common : HTTPMethod;
 public import vibe.http.client : HTTPClientRequest;
 public import vibe.http.server : HTTPServerRequest, HTTPServerResponse;
 public import std.functional : toDelegate;
-public import vibe.data.json : Json;
+public import vibe.data.json : deserializeJson, Json;
 public import std.datetime : SysTime;
 
 // existing dlang bot comment -> update comment


### PR DESCRIPTION
Problem: users don't have the permission to add labels.

The idea is simple: the bot parses the PR title for a pre-approved list, e.g.

[Trivial] -> add "Trivial" label

Currently this function will get checked "open" or edited" events.
Gotchas:
- There wasn't an edited hook payload in the data set (should be similar to open though)
- For now it doesn't remove these added labels (but this is seldom required anyways)