### PR TITLE
Show warnings in comment (for now: regression PR not against master)

### DIFF
--- a/data/payloads/bugzilla_buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc
+++ b/data/payloads/bugzilla_buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc
@@ -1,2 +1,0 @@
-bug_id,"short_desc"
-16794,"dmd not working on Ubuntu 16.10 because of default PIE linking"

--- a/data/payloads/bugzilla_buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority
+++ b/data/payloads/bugzilla_buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority
@@ -1,0 +1,2 @@
+bug_id,"short_desc","bug_status","resolution","bug_severity","priority"
+16794,"dmd not working on Ubuntu 16.10 because of default PIE linking","RESOLVED","FIXED","critical","P1"

--- a/data/payloads/bugzilla_buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc
+++ b/data/payloads/bugzilla_buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc
@@ -1,2 +1,0 @@
-bug_id,"short_desc"
-8573,"A simpler Phobos function that returns the index of the mix or max item"

--- a/data/payloads/bugzilla_buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority
+++ b/data/payloads/bugzilla_buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority
@@ -1,0 +1,2 @@
+bug_id,"short_desc","bug_status","resolution","bug_severity","priority"
+8573,"A simpler Phobos function that returns the index of the mix or max item","NEW","---","enhancement","P2"

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -176,7 +176,7 @@ void handlePR(string action, PullRequest* _pr)
     UserMessage[] msgs;
     if (action == "opened" || action == "synchronize")
     {
-        //msgs = pr.checkForWarnings;
+        msgs = pr.checkForWarnings(descs);
     }
 
     pr.updateGithubComment(comment, action, refs, descs, msgs);

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -140,6 +140,7 @@ void handlePR(string action, PullRequest* _pr)
 {
     import std.algorithm : any;
     import vibe.core.core : setTimer;
+    import dlangbot.warnings : checkForWarnings, UserMessage;
 
     const PullRequest pr = *_pr;
 
@@ -172,7 +173,13 @@ void handlePR(string action, PullRequest* _pr)
     auto descs = getDescriptions(refs);
     auto comment = pr.getBotComment;
 
-    pr.updateGithubComment(comment, action, refs, descs);
+    UserMessage[] msgs;
+    if (action == "opened" || action == "synchronize")
+    {
+        //msgs = pr.checkForWarnings;
+    }
+
+    pr.updateGithubComment(comment, action, refs, descs, msgs);
 
     if (refs.any!(r => r.fixed) && comment.body_.length == 0)
         pr.addLabels(["Bug fix"]);

--- a/source/dlangbot/bugzilla.d
+++ b/source/dlangbot/bugzilla.d
@@ -51,9 +51,9 @@ struct Issue
 {
     int id;
     string desc;
-    string bug_status;
+    string status;
     string resolution;
-    string bug_severity;
+    string severity;
     string priority;
 }
 

--- a/source/dlangbot/bugzilla.d
+++ b/source/dlangbot/bugzilla.d
@@ -47,7 +47,15 @@ IssueRef[] getIssueRefs(Json[] commits)
     return issues;
 }
 
-struct Issue { int id; string desc; }
+struct Issue
+{
+    int id;
+    string desc;
+    string bug_status;
+    string resolution;
+    string bug_severity;
+    string priority;
+}
 
 // get pairs of (issue number, short descriptions) from bugzilla
 Issue[] getDescriptions(R)(R issueRefs)
@@ -58,7 +66,7 @@ Issue[] getDescriptions(R)(R issueRefs)
 
     if (issueRefs.empty)
         return null;
-    return "%s/buglist.cgi?bug_id=%(%d,%)&ctype=csv&columnlist=short_desc"
+    return "%s/buglist.cgi?bug_id=%(%d,%)&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority"
         .format(bugzillaURL, issueRefs.map!(r => r.id))
         .requestHTTP
         .bodyReader.readAllUTF8
@@ -67,5 +75,3 @@ Issue[] getDescriptions(R)(R issueRefs)
         .sort!((a, b) => a.id < b.id)
         .release;
 }
-
-

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -4,6 +4,7 @@ string githubAPIURL = "https://api.github.com";
 string githubAuth, hookSecret;
 
 import dlangbot.bugzilla : bugzillaURL, Issue, IssueRef;
+import dlangbot.warnings : printMessages, UserMessage;
 
 import std.algorithm, std.range;
 import std.datetime;
@@ -20,12 +21,28 @@ import vibe.stream.operations : readAllUTF8;
 // Github comments
 //==============================================================================
 
-string formatComment(in ref PullRequest pr, in IssueRef[] refs, in Issue[] descs)
+void printBugList(W, R1, R2)(W app, R1 refs, R2 descs)
+{
+
+    if (refs.length > 0)
+    {
+        auto combined = zip(refs.map!(r => r.id), refs.map!(r => r.fixed), descs.map!(d => d.desc));
+        app.put("Fix | Bugzilla | Description\n");
+        app.put("--- | --- | ---\n");
+        foreach (num, closed, desc; combined)
+        {
+            app.formattedWrite(
+                "%1$s | [%2$s](%4$s/show_bug.cgi?id=%2$s) | %3$s\n",
+                closed ? "✓" : "✗", num, desc, bugzillaURL);
+        }
+    }
+}
+
+string formatComment(R1, R2)(R1 refs, R2 descs, UserMessage[] msgs)
 {
     import std.array : appender;
-    import std.format : formattedWrite;
-
-    auto app = appender!string();
+    auto app = appender!string;
+    
     app.formattedWrite(
 `Thanks for your pull request, @%s!  We are looking forward to reviewing it, and you should be hearing from a maintainer soon.
 
@@ -43,17 +60,15 @@ Please see [CONTRIBUTING.md](https://github.com/%s/blob/master/CONTRIBUTING.md) 
 
 `, pr.user.login, pr.repoSlug);
 
-    if (refs.length > 0)
+    if (refs.length)
     {
-        auto combined = zip(refs.map!(r => r.id), refs.map!(r => r.fixed), descs.map!(d => d.desc));
-        app.put("Fix | Bugzilla | Description\n");
-        app.put("--- | --- | ---\n");
-        foreach (num, closed, desc; combined)
-        {
-            app.formattedWrite(
-                "%1$s | [%2$s](%4$s/show_bug.cgi?id=%2$s) | %3$s\n",
-                closed ? "✓" : "✗", num, desc, bugzillaURL);
-        }
+        app ~= "### Bugzilla references\n\n";
+        app.printBugList(refs, descs);
+    }
+    if (msgs.length)
+    {
+        app ~= "### Warnings \n\n";
+        app.printMessages(msgs);
     }
     return app.data;
 }
@@ -113,13 +128,14 @@ auto ghSendRequest(T...)(HTTPMethod method, string url, T arg)
     }, url);
 }
 
-void updateGithubComment(in ref PullRequest pr, in ref GHComment comment, string action, IssueRef[] refs, Issue[] descs)
+void updateGithubComment(in ref PullRequest pr, in ref GHComment comment,
+                         string action, IssueRef[] refs, Issue[] descs, UserMessage[] msgs)
 {
     logDebug("%s", refs);
     logDebug("%s", descs);
     assert(refs.map!(r => r.id).equal(descs.map!(d => d.id)));
 
-    auto msg = pr.formatComment(refs, descs);
+    auto msg = pr.formatComment(refs, descs, msgs);
     logDebug("%s", msg);
 
     if (msg != comment.body_)

--- a/source/dlangbot/warnings.d
+++ b/source/dlangbot/warnings.d
@@ -1,10 +1,14 @@
 module dlangbot.warnings;
 
+import dlangbot.bugzilla : Issue;
 import dlangbot.github : PullRequest;
+
+import std.algorithm;
 
 struct UserMessage
 {
     enum Type { Error, Warning, Info }
+    Type type;
 
     string text;
 }
@@ -21,24 +25,35 @@ Check bugzilla priority
 - enhancement -> changelog entry
 - regression/major -> stable
 */
-void checkBugzilla(in ref PullRequest pr, UserMessage[] msgs)
+void checkBugzilla(in ref PullRequest pr, ref UserMessage[] msgs, in Issue[] bugzillaIssues)
 {
+    // check for stable
+    if (pr.base.ref_ != "stable")
+    {
+        if (bugzillaIssues.any!(i => i.status.among("NEW", "ASSIGNED") &&
+                                     i.severity.among("critical", "major",
+                                                      "blocker", "regression")))
+        {
+            msgs ~= UserMessage(UserMessage.Type.Warning,
+                "Regression fixes should always target stable");
+        }
+    }
 }
 
 
-UserMessage[] checkForWarnings(in PullRequest pr)
+UserMessage[] checkForWarnings(in PullRequest pr, in Issue[] bugzillaIssues)
 {
     UserMessage[] msgs;
     pr.checkDiff(msgs);
-    pr.checkBugzilla(msgs);
+    pr.checkBugzilla(msgs, bugzillaIssues);
     return msgs;
 }
 
-void printMessages(W)(W app, UserMessage[] msgs)
+void printMessages(W)(W app, in UserMessage[] msgs)
 {
     foreach (msg; msgs)
     {
-        app ~= " - ";
+        app ~= "- ";
         app ~= msg.text;
         app ~= "\n";
     }

--- a/source/dlangbot/warnings.d
+++ b/source/dlangbot/warnings.d
@@ -1,0 +1,45 @@
+module dlangbot.warnings;
+
+import dlangbot.github : PullRequest;
+
+struct UserMessage
+{
+    enum Type { Error, Warning, Info }
+
+    string text;
+}
+
+
+// check diff length
+void checkDiff(in ref PullRequest pr, ref UserMessage[] msgs)
+{
+}
+
+
+/**
+Check bugzilla priority
+- enhancement -> changelog entry
+- regression/major -> stable
+*/
+void checkBugzilla(in ref PullRequest pr, UserMessage[] msgs)
+{
+}
+
+
+UserMessage[] checkForWarnings(in PullRequest pr)
+{
+    UserMessage[] msgs;
+    pr.checkDiff(msgs);
+    pr.checkBugzilla(msgs);
+    return msgs;
+}
+
+void printMessages(W)(W app, UserMessage[] msgs)
+{
+    foreach (msg; msgs)
+    {
+        app ~= " - ";
+        app ~= msg.text;
+        app ~= "\n";
+    }
+}

--- a/test/comments.d
+++ b/test/comments.d
@@ -9,7 +9,7 @@ unittest
         "/github/repos/dlang/phobos/pulls/4921/commits",
         "/github/repos/dlang/phobos/issues/4921/labels",
         "/github/repos/dlang/phobos/issues/4921/comments",
-        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc",
+        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         "/github/repos/dlang/phobos/issues/comments/262784442",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
@@ -37,7 +37,7 @@ unittest
         "/github/repos/dlang/phobos/issues/4921/comments", (ref Json j) {
             j = Json.emptyArray;
         },
-        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc",
+        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         // no bug fix label, since Issues are only referenced but not fixed according to commit messages
         "/github/repos/dlang/phobos/issues/4921/comments",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){

--- a/test/comments.d
+++ b/test/comments.d
@@ -14,7 +14,9 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.PATCH);
             auto expectedComment =
-`Fix | Bugzilla | Description
+`### Bugzilla references
+
+Fix | Bugzilla | Description
 --- | --- | ---
 ✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 `.format(bugzillaURL);
@@ -41,7 +43,9 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.POST);
             auto expectedComment =
-`Fix | Bugzilla | Description
+`### Bugzilla references
+
+Fix | Bugzilla | Description
 --- | --- | ---
 ✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 `.format(bugzillaURL);

--- a/test/comments.d
+++ b/test/comments.d
@@ -144,3 +144,45 @@ unittest
 
     postGitHubHook("dlang_phobos_merged_4963.json");
 }
+
+// critical bug fix (not in stable) -> show warning to target stable
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/phobos/pulls/4921/commits",
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/repos/dlang/phobos/issues/4921/comments", (ref Json j) {
+            j = Json.emptyArray;
+        },
+        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            res.writeBody(
+`bug_id,"short_desc","bug_status","resolution","bug_severity","priority"
+8573,"A simpler Phobos function that returns the index of the mix or max item","NEW","---","regression","P2"`);
+        },
+        // no bug fix label, since Issues are only referenced but not fixed according to commit messages
+        "/github/repos/dlang/phobos/issues/4921/comments",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            import std.stdio;
+            assert(req.method == HTTPMethod.POST);
+            writeln(req.json["body"]);
+            auto expectedComment =
+`### Bugzilla references
+
+Fix | Bugzilla | Description
+--- | --- | ---
+✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
+
+### Warnings
+
+- Regression fixes should always target stable
+`.format(bugzillaURL);
+            writeln(expectedComment);
+            assert(req.json["body"].get!string.canFind(expectedComment));
+            res.writeVoidBody;
+        },
+        "/trello/1/search?query=name:%22Issue%208573%22&"~trelloAuth,
+    );
+
+    postGitHubHook("dlang_phobos_synchronize_4921.json");
+}

--- a/test/trello.d
+++ b/test/trello.d
@@ -6,7 +6,7 @@ import std.stdio, std.format : format;
 unittest
 {
     setAPIExpectations(
-        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc",
+        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         "/trello/1/cards/583f517a333add7c28e0cec7/actions?filter=commentCard&"~trelloAuth,
         (ref Json j) { j = Json.emptyArray; },
         "/trello/1/cards/583f517a333add7c28e0cec7/actions/comments?"~trelloAuth,
@@ -25,7 +25,7 @@ unittest
 unittest
 {
     setAPIExpectations(
-        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc",
+        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         "/trello/1/cards/583f517a333add7c28e0cec7/actions?filter=commentCard&"~trelloAuth,
         (ref Json j) { j[0]["data"]["text"] = "- [Issue 16794 - bla bla](https://issues.dlang.org/show_bug.cgi?id=16794)\n"; },
         "/trello/1/cards/583f517a333add7c28e0cec7/actions/583f517b91413ef81f1f9d34/comments?"~trelloAuth,
@@ -46,7 +46,7 @@ unittest
     setAPIExpectations(
         "/github/repos/dlang/dmd/pulls/6359/commits",
         "/github/repos/dlang/dmd/issues/6359/comments",
-        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc",
+        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         "/github/repos/dlang/dmd/issues/6359/comments",
         // action: add bug fix label
         "/github/repos/dlang/dmd/issues/6359/labels",
@@ -79,7 +79,7 @@ unittest
     setAPIExpectations(
         "/github/repos/dlang/dmd/pulls/6359/commits",
         "/github/repos/dlang/dmd/issues/6359/comments",
-        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc",
+        "/bugzilla/buglist.cgi?bug_id=16794&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         "/github/repos/dlang/dmd/issues/6359/comments",
         // action: add bug fix label
         "/github/repos/dlang/dmd/issues/6359/labels",


### PR DESCRIPTION
A first attempt to show helpful warnings (or errors) to a PR submitter (#8).

- In the first commit this adds `warnings.d` where in the future more warning generator can lay. This commit doesn't modify the output.

- The second commit extends the bugzilla query by requesting more attributes (e.g. severity)

- The third commit combines the first two and emits a warnings when a critical/major/regression/blocking PR isn't based onto stable

Again this is meant as first iteration and we probably have to fine tune this (and can hopefully add more warning generators).
One refactoring step that we should do in any case is to find a common "Cache" format for all information already requested by the diverse APIs - passing them around as function parameters doesn't scale that well.