### PR TITLE
Reduce throttled limit to one minute

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -21,7 +21,7 @@ import vibe.stream.operations : readAllUTF8;
 bool runAsync = true;
 bool runTrello = true;
 
-Duration timeBetweenFullPRChecks = 5.minutes; // this should never be larger 30 mins on heroku
+Duration timeBetweenFullPRChecks = 1.minutes; // this should never be larger 30 mins on heroku
 Throttler!(typeof(&searchForAutoMergePrs)) prThrottler;
 
 enum trelloHookURL = "https://dlang-bot.herokuapp.com/trello_hook";


### PR DESCRIPTION
We could also go for two minutes, but I think I doesn't matter much in terms of used requests per hour and it gives people a more "real-time" experience