### PR TITLE
Only comment for repos of dlang & dlang-bots GH organizations

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -141,7 +141,7 @@ void cronDaily()
 
 void handlePR(string action, PullRequest* _pr)
 {
-    import std.algorithm : any;
+    import std.algorithm : among, any;
     import vibe.core.core : setTimer;
     import dlangbot.warnings : checkForWarnings, UserMessage;
 
@@ -183,7 +183,8 @@ void handlePR(string action, PullRequest* _pr)
         msgs = pr.checkForWarnings(descs);
     }
 
-    pr.updateGithubComment(comment, action, refs, descs, msgs);
+    if (pr.base.repo.owner.login.among("dlang", "dlang-bots"))
+        pr.updateGithubComment(comment, action, refs, descs, msgs);
 
     if (refs.any!(r => r.fixed))
     {


### PR DESCRIPTION
I have seen that the comment of the dlang-bot isn't universally popular, so let's make the bot's feature opt-in. As the bot isn't very well used atm, a simple hard-coded list should do fine.

CC @BBasile