### PR TITLE
Let warnings stand out more

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -87,7 +87,7 @@ If your PR contains non-trivial changes, please [reference a Bugzilla issue](htt
     {
         if (refs.length)
             app ~= "\n";
-        app ~= "### Warnings\n\n";
+        app ~= "### ⚠️⚠️⚠️ Warnings ⚠️⚠️⚠️\n\n";
         app.printMessages(msgs);
     }
     return app.data;

--- a/source/dlangbot/warnings.d
+++ b/source/dlangbot/warnings.d
@@ -35,7 +35,8 @@ void checkBugzilla(in ref PullRequest pr, ref UserMessage[] msgs, in Issue[] bug
                                                       "blocker", "regression")))
         {
             msgs ~= UserMessage(UserMessage.Type.Warning,
-                "Regression fixes should always target stable");
+                "Regression or critical bug fixes should always target the `stable` branch." ~
+                " [Learn more](https://wiki.dlang.org/Starting_as_a_Contributor#Stable_Branch)");
         }
     }
 }

--- a/test/comments.d
+++ b/test/comments.d
@@ -239,16 +239,16 @@ unittest
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.POST);
             auto expectedComment =
-`### Bugzilla references
+"### Bugzilla references
 
 Fix | Bugzilla | Description
 --- | --- | ---
 ✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 
-### Warnings
+### ⚠️⚠️⚠️ Warnings ⚠️⚠️⚠️
 
-- Regression fixes should always target stable
-`.format(bugzillaURL);
+- Regression or critical bug fixes should always target the `stable` branch. [Learn more](https://wiki.dlang.org/Starting_as_a_Contributor#Stable_Branch)
+".format(bugzillaURL);
             assert(req.json["body"].get!string.canFind(expectedComment));
             res.writeVoidBody;
         },


### PR DESCRIPTION
From https://github.com/dlang/dmd/pull/6928#issuecomment-312481565.

I didn't use UPPERCASE as the other headings don't use UPPERCASE and it looked a bit weird.

### Preview

-----

![image](https://user-images.githubusercontent.com/4370550/27768983-9ec28c36-5f20-11e7-8c5e-b55dca7e8cc3.png)

-----

We might also opt for a table format like [Danger uses](https://github.com/dlang-bots/dlang-bot/issues/8#issuecomment-279986625).