### PR TITLE
Fix #119 - Don't edit the Bot's comment if the PR has been closed/merged

### DIFF
--- a/data/hooks/github/dlang_phobos_synchronize_4921.json
+++ b/data/hooks/github/dlang_phobos_synchronize_4921.json
@@ -9,7 +9,7 @@
     "patch_url": "https://github.com/dlang/phobos/pull/4921.patch",
     "issue_url": "https://api.github.com/repos/dlang/phobos/issues/4921",
     "number": 4921,
-    "state": "closed",
+    "state": "open",
     "locked": false,
     "title": "[DEMO for DIP1005] Converted imports to selective imports in std.array",
     "user": {

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -164,17 +164,19 @@ void handlePR(string action, PullRequest* _pr)
 
     if (action == "labeled" || action == "synchronize")
     {
-        auto labelsAndCommits = handleGithubLabel(pr);
+        auto labels = pr.labels;
         if (action == "labeled")
+        {
+            if (auto method = labels.autoMergeMethod)
+                commits = pr.tryMerge(method);
             return;
+        }
         if (action == "synchronize")
         {
             logDebug("[github/handlePR](%s): checkAndRemoveLabels", _pr.pid);
             enum toRemoveLabels = ["auto-merge", "auto-merge-squash",
                                    "needs rebase", "needs work"];
-            checkAndRemoveLabels(labelsAndCommits.labels, pr, toRemoveLabels);
-            if (labelsAndCommits.commits !is null)
-                commits = labelsAndCommits.commits;
+            checkAndRemoveLabels(labels, pr, toRemoveLabels);
         }
     }
 

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -132,8 +132,6 @@ void updateGithubComment(in ref PullRequest pr, in ref GHComment comment,
 // Github Auto-merge
 //==============================================================================
 
-alias LabelsAndCommits = Tuple!(GHLabel[], "labels", Json[], "commits");
-
 string labelName(GHMerge.MergeMethod method)
 {
     final switch (method) with (GHMerge.MergeMethod)
@@ -158,17 +156,6 @@ GHMerge.MergeMethod autoMergeMethod(GHLabel[] labels)
             return rebase;
         return none;
     }
-}
-
-auto handleGithubLabel(in ref PullRequest pr)
-{
-    auto labels = pr.labels;
-
-    Json[] commits;
-    if (auto method = labels.autoMergeMethod)
-        commits = pr.tryMerge(method);
-
-    return LabelsAndCommits(labels, commits);
 }
 
 Json[] tryMerge(in ref PullRequest pr, GHMerge.MergeMethod method)

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -107,6 +107,10 @@ GHComment getBotComment(in ref PullRequest pr)
 void updateGithubComment(in ref PullRequest pr, in ref GHComment comment,
                          string action, IssueRef[] refs, Issue[] descs, UserMessage[] msgs)
 {
+    // The history should be preserved and modifications after a merge/closed event are seldomly seen
+    if (pr.state == GHState.closed)
+        return;
+
     logDebug("[github/updateGithubComment](%s): %s", pr.pid, refs);
     logDebug("%s", descs);
     assert(refs.map!(r => r.id).equal(descs.map!(d => d.id)));

--- a/test/comments.d
+++ b/test/comments.d
@@ -211,7 +211,6 @@ unittest
     setAPIExpectations(
         "/github/repos/dlang/phobos/pulls/4963/commits",
         "/github/repos/dlang/phobos/issues/4963/comments",
-        "/github/orgs/dlang/public_members?per_page=100",
     );
 
     postGitHubHook("dlang_phobos_merged_4963.json");
@@ -291,12 +290,6 @@ unittest
             assert(req.method == HTTPMethod.DELETE);
             res.statusCode = 200;
         },
-        "/github/repos/dlang/phobos/issues/5519/events",
-        "/github/users/MartinNowak",
-        "/github/repos/dlang/phobos/pulls/5519/merge",
-        (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            res.statusCode = 200;
-        },
         "/bugzilla/buglist.cgi?bug_id=17564&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
         "/github/repos/dlang/phobos/issues/5519/comments",
         "/github/orgs/dlang/public_members?per_page=100",
@@ -332,4 +325,20 @@ unittest
     );
 
     postGitHubHook("dlang_phobos_edit_5519.json");
+}
+
+// #119 - don't edit the comment for closed PRs
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/phobos/pulls/4921/commits",
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/repos/dlang/phobos/issues/4921/comments",
+        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
+        "/trello/1/search?query=name:%22Issue%208573%22&"~trelloAuth,
+    );
+
+    postGitHubHook("dlang_phobos_synchronize_4921.json", "pull_request", (ref Json j, scope req) {
+        j["pull_request"]["state"] = "closed";
+    });
 }


### PR DESCRIPTION
Discovered a small issue during this (see the second commit - the bot previously tried to send an auto-merge immediately on a synchronize event. We never noticed this because luckily the GH required checks prevented this form becoming an issue)