### PR TITLE
Rename Fix to Auto-Close

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -20,7 +20,7 @@ public import dlangbot.github_api;
 void printBugList(W)(W app, in IssueRef[] refs, in Issue[] descs)
 {
     auto combined = zip(refs.map!(r => r.id), refs.map!(r => r.fixed), descs.map!(d => d.desc));
-    app.put("Fix | Bugzilla | Description\n");
+    app.put("Auto-close | Bugzilla | Description\n");
     app.put("--- | --- | ---\n");
     foreach (num, closed, desc; combined)
     {

--- a/test/comments.d
+++ b/test/comments.d
@@ -17,7 +17,7 @@ unittest
             auto expectedComment =
 `### Bugzilla references
 
-Fix | Bugzilla | Description
+Auto-close | Bugzilla | Description
 --- | --- | ---
 ✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 `.format(bugzillaURL);
@@ -47,7 +47,7 @@ unittest
             auto expectedComment =
 `### Bugzilla references
 
-Fix | Bugzilla | Description
+Auto-close | Bugzilla | Description
 --- | --- | ---
 ✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 `.format(bugzillaURL);
@@ -79,7 +79,7 @@ unittest
             assert(req.method == HTTPMethod.PATCH);
             auto body_= req.json["body"].get!string;
             assert(body_.canFind("@andralex"));
-            assert(!body_.canFind("Fix | Bugzilla"), "Shouldn't contain bug header");
+            assert(!body_.canFind("Auto-close | Bugzilla"), "Shouldn't contain bug header");
             assert(!body_.canFind("/show_bug.cgi?id="), "Shouldn't contain a Bugzilla reference");
         }
     );
@@ -107,7 +107,7 @@ unittest
             assert(req.method == HTTPMethod.PATCH);
             auto body_= req.json["body"].get!string;
             assert(body_.canFind("@andralex"));
-            assert(!body_.canFind("Fix | Bugzilla"), "Shouldn't contain bug header");
+            assert(!body_.canFind("Auto-close | Bugzilla"), "Shouldn't contain bug header");
             assert(!body_.canFind("/show_bug.cgi?id="), "Shouldn't contain a Bugzilla reference");
         }
     );
@@ -240,7 +240,7 @@ unittest
             auto expectedComment =
 "### Bugzilla references
 
-Fix | Bugzilla | Description
+Auto-close | Bugzilla | Description
 --- | --- | ---
 ✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 


### PR DESCRIPTION
People repeatedly have shown problems to recognize that a cross (✗)
means that the PR won't be automatically closed (and shown as part of the changelog).
While this has been documented in #124, the best solution is to directly display the meaning
on the Bot's comment.

Follow-up to https://github.com/dlang-bots/dlang-bot/pull/124#issuecomment-313382374