### PR TITLE
Remove allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ d:
  - ldc
 
 matrix:
-  allow_failures:
-    - d: ldc
-    - d: dmd-beta # temporarily disabled due to https://issues.dlang.org/show_bug.cgi?id=17614
   include:
     - d: dmd-2.070.2 # the deployment compiler
       env: COVERAGE=true


### PR DESCRIPTION
- LDC 1.3.0 got released
- DMD 2.075.0-b4 should fix the __VERSION__ regression in Vibe.d