### PR TITLE
Fix #138 - Warning regression fix should always target stable should only be shown for PRs that close open issues

### DIFF
--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -196,7 +196,7 @@ void handlePR(string action, PullRequest* _pr)
     UserMessage[] msgs;
     if (action == "opened" || action == "synchronize")
     {
-        msgs = pr.checkForWarnings(descs);
+        msgs = pr.checkForWarnings(descs, refs);
     }
 
     if (pr.base.repo.owner.login.among("dlang", "dlang-bots"))

--- a/source/dlangbot/warnings.d
+++ b/source/dlangbot/warnings.d
@@ -1,6 +1,6 @@
 module dlangbot.warnings;
 
-import dlangbot.bugzilla : Issue;
+import dlangbot.bugzilla : Issue, IssueRef;
 import dlangbot.github : PullRequest;
 
 import std.algorithm;
@@ -25,14 +25,16 @@ Check bugzilla priority
 - enhancement -> changelog entry
 - regression/major -> stable
 */
-void checkBugzilla(in ref PullRequest pr, ref UserMessage[] msgs, in Issue[] bugzillaIssues)
+void checkBugzilla(in ref PullRequest pr, ref UserMessage[] msgs,
+        in Issue[] bugzillaIssues, in IssueRef[] refs)
 {
     // check for stable
     if (pr.base.ref_ != "stable")
     {
-        if (bugzillaIssues.any!(i => i.status.among("NEW", "ASSIGNED") &&
+        if (bugzillaIssues.any!(i => i.status.among("NEW", "ASSIGNED", "REOPENED") &&
                                      i.severity.among("critical", "major",
-                                                      "blocker", "regression")))
+                                                      "blocker", "regression") &&
+                                     refs.canFind!(r => r.id == i.id && r.fixed)))
         {
             msgs ~= UserMessage(UserMessage.Type.Warning,
                 "Regression or critical bug fixes should always target the `stable` branch." ~
@@ -42,11 +44,11 @@ void checkBugzilla(in ref PullRequest pr, ref UserMessage[] msgs, in Issue[] bug
 }
 
 
-UserMessage[] checkForWarnings(in PullRequest pr, in Issue[] bugzillaIssues)
+UserMessage[] checkForWarnings(in PullRequest pr, in Issue[] bugzillaIssues, in IssueRef[] refs)
 {
     UserMessage[] msgs;
     pr.checkDiff(msgs);
-    pr.checkBugzilla(msgs, bugzillaIssues);
+    pr.checkBugzilla(msgs, bugzillaIssues, refs);
     return msgs;
 }
 

--- a/test/comments.d
+++ b/test/comments.d
@@ -220,7 +220,9 @@ unittest
 unittest
 {
     setAPIExpectations(
-        "/github/repos/dlang/phobos/pulls/4921/commits",
+        "/github/repos/dlang/phobos/pulls/4921/commits", (ref Json j) {
+            j[0]["commit"]["message"] = "Fix Issue 8573";
+        },
         "/github/repos/dlang/phobos/issues/4921/labels",
         "/github/repos/dlang/phobos/issues/4921/comments", (ref Json j) {
             j = Json.emptyArray;
@@ -232,7 +234,11 @@ unittest
 8573,"A simpler Phobos function that returns the index of the mix or max item","NEW","---","regression","P2"`);
         },
         "/github/orgs/dlang/public_members?per_page=100",
-        // no bug fix label, since Issues are only referenced but not fixed according to commit messages
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            res.writeJsonBody(Json.emptyArray);
+        },
         "/github/repos/dlang/phobos/issues/4921/comments",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
             assert(req.method == HTTPMethod.POST);
@@ -241,7 +247,7 @@ unittest
 
 Auto-close | Bugzilla | Description
 --- | --- | ---
-✗ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
+✓ | [8573](%s/show_bug.cgi?id=8573) | A simpler Phobos function that returns the index of the mix or max item
 
 ### ⚠️⚠️⚠️ Warnings ⚠️⚠️⚠️
 
@@ -341,4 +347,64 @@ unittest
     postGitHubHook("dlang_phobos_synchronize_4921.json", "pull_request", (ref Json j, scope req) {
         j["pull_request"]["state"] = "closed";
     });
+}
+
+// #138 - don't show stable warning for PRs that don't close an issue
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/phobos/pulls/4921/commits", (ref Json j) {
+            j[0]["commit"]["message"] = "Issue 8573";
+        },
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/repos/dlang/phobos/issues/4921/comments", (ref Json j) {
+            j = Json.emptyArray;
+        },
+        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            res.writeBody(
+`bug_id,"short_desc","bug_status","resolution","bug_severity","priority"
+8573,"A simpler Phobos function that returns the index of the mix or max item","NEW","---","regression","P2"`);
+        },
+        "/github/orgs/dlang/public_members?per_page=100",
+        "/github/repos/dlang/phobos/issues/4921/comments",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            assert(req.method == HTTPMethod.POST);
+            assert(!req.json["body"].get!string.canFind("Regression or critical bug fixes"));
+        },
+        "/trello/1/search?query=name:%22Issue%208573%22&"~trelloAuth,
+    );
+
+    postGitHubHook("dlang_phobos_synchronize_4921.json");
+}
+
+// #138 - don't show stable warning for PRs with closed issues
+unittest
+{
+    setAPIExpectations(
+        "/github/repos/dlang/phobos/pulls/4921/commits", (ref Json j) {
+            j[0]["commit"]["message"] = "Fix Issue 8573";
+        },
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/repos/dlang/phobos/issues/4921/comments", (ref Json j) {
+            j = Json.emptyArray;
+        },
+        "/bugzilla/buglist.cgi?bug_id=8573&ctype=csv&columnlist=short_desc,bug_status,resolution,bug_severity,priority",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            res.writeBody(
+`bug_id,"short_desc","bug_status","resolution","bug_severity","priority"
+8573,"A simpler Phobos function that returns the index of the mix or max item","CLOSED","---","regression","P2"`);
+        },
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/repos/dlang/phobos/issues/4921/labels",
+        "/github/orgs/dlang/public_members?per_page=100",
+        "/github/repos/dlang/phobos/issues/4921/comments",
+        (scope HTTPServerRequest req, scope HTTPServerResponse res){
+            assert(req.method == HTTPMethod.POST);
+            assert(!req.json["body"].get!string.canFind("Regression or critical bug fixes"));
+        },
+        "/trello/1/search?query=name:%22Issue%208573%22&"~trelloAuth,
+    );
+
+    postGitHubHook("dlang_phobos_synchronize_4921.json");
 }


### PR DESCRIPTION
See https://github.com/dlang-bots/dlang-bot/issues/138