### PR TITLE
Revert "Upgrade DUB dependencies"

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -2,7 +2,7 @@ name "dlang-bot"
 description "dlang-bot for automated bugzilla, github, and trello references"
 copyright "Copyright © 2015, Martin Nowak"
 authors "Martin Nowak"
-dependency "vibe-d" version="~>0.8.0"
+dependency "vibe-d" version="~>0.7.30"
 configuration "default" {
 	versions "VibeCustomMain"
 	targetType "executable"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,16 +1,11 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"botan": "1.12.9",
-		"botan-math": "1.0.3",
-		"diet-ng": "1.2.1",
-		"eventcore": "0.8.12",
-		"libasync": "0.8.3",
+		"diet-ng": "1.2.0",
+		"libasync": "0.7.9",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
 		"openssl": "1.1.5+1.0.1g",
-		"taggedalgebraic": "0.10.7",
-		"vibe-core": "1.0.0",
-		"vibe-d": "0.8.0"
+		"vibe-d": "0.7.31-rc.2"
 	}
 }

--- a/source/dlangbot/app.d
+++ b/source/dlangbot/app.d
@@ -43,7 +43,7 @@ void startServer(HTTPServerSettings settings)
         .get("/", (req, res) => res.render!"index.dt")
         .get("*", serveStaticFiles("public"))
         .post("/github_hook", &githubHook)
-        .match(HTTPMethod.HEAD, "/trello_hook", (HTTPServerRequest req, HTTPServerResponse res) => res.writeVoidBody)
+        .match(HTTPMethod.HEAD, "/trello_hook", (req, res) => res.writeVoidBody)
         .post("/trello_hook", &trelloHook)
         .post("/codecov_hook", &codecovHook)
         ;


### PR DESCRIPTION
Reverts dlang-bots/dlang-bot#137

The logs don't look good:

![image](https://user-images.githubusercontent.com/4370550/28438267-dc5861e8-6d9d-11e7-8159-3bf8149c5009.png)

As this was the only change in the last days, let's better revert this for now
