### PR TITLE
unit-threaded for the win

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dlang-bot
 __test__unittest__
 dlang-bot-test-unittest
+ut.d # unit-threaded
 
 # Created by https://www.gitignore.io/api/d
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ d:
  - ldc-beta
  - ldc
 
+script:
+  # Tests are neither random- nor parallelizable atm., so use a --single serial thread.
+  - dub test --compiler=$DC -- --single --trace
+
 addons:
   apt:
     packages:
@@ -19,8 +23,9 @@ matrix:
     - d: dmd-2.077.1 # the deployment compiler
       env: COVERAGE=true
       script:
-        # https://issues.dlang.org/show_bug.cgi?id=13742
-        - dub test --compiler=$DC --build=unittest-cov --build-mode=singleFile
+        # Use --build-mode=singleFile to workaround https://issues.dlang.org/show_bug.cgi?id=13742
+        # Tests are neither random- nor parallelizable atm., so use a --single serial thread.
+        - dub test --compiler=$DC --build=unittest-cov --build-mode=singleFile -- --single --trace
       after_success:
         - bash <(curl -s https://codecov.io/bash)
   allow_failures:

--- a/dub.sdl
+++ b/dub.sdl
@@ -4,13 +4,15 @@ copyright "Copyright © 2015, Martin Nowak"
 authors "Martin Nowak"
 dependency "vibe-d" version="~>0.8.0"
 subConfiguration "vibe-d:core" "vibe-core"
-configuration "default" {
-	versions "VibeCustomMain"
-	targetType "executable"
+targetType "executable"
+
+configuration "executable" {
 }
+
 configuration "unittest" {
-	versions "VibeCustomMain"
-	sourcePaths "source" "test"
-	importPaths "source" "test"
-	stringImportPaths "views"
+    dependency "unit-threaded" version="~>0.7.11"
+    mainSourceFile "ut.d"
+    preBuildCommands "dub run unit-threaded -c gen_ut_main -- -f ut.d"
+    sourcePaths "source" "test"
+    importPaths "source" "test"
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -11,6 +11,7 @@
 		"openssl": "1.1.6+1.0.1g",
 		"stdx-allocator": "2.77.0",
 		"taggedalgebraic": "0.10.8",
+		"unit-threaded": "0.7.36",
 		"vibe-core": "1.4.0-alpha.1",
 		"vibe-d": "0.8.3-alpha.1"
 	}


### PR DESCRIPTION
- use --single for now as tests are neither random- nor parallelizable atm.

also see #167, improves finding failing tests and allows to (re-)run single tests.

```sh
dub test -- --single --trace comments
dub test -- --single --trace comments.remove-auto-merge-on-sync
```