### PR TITLE
Disable sending the sha explicitly to GitHub on tryMerge

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -200,7 +200,9 @@ Json[] tryMerge(in ref PullRequest pr, GHMerge.MergeMethod method)
     logDebug("[github/tryMerge/commits](%s): %s", pr.pid, commits[$ - 1]);
     GHMerge mergeInput = {
         commitMessage: "%s\nmerged-on-behalf-of: %s".format(pr.title, author),
-        sha: commits[$ - 1]["sha"].get!string,
+        // disabled due to mismatching head conflicts
+        // see: https://github.com/dlang-bots/dlang-bot/issues/77
+        //sha: commits[$ - 1]["sha"].get!string,
         mergeMethod: method
     };
     pr.postMerge(mergeInput);

--- a/test/labels.d
+++ b/test/labels.d
@@ -45,7 +45,6 @@ unittest
         "/github/repos/dlang/phobos/pulls/4921/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res) {
             // https://developer.github.com/v3/pulls/#response-if-merge-cannot-be-performed
-            assert(req.json["sha"] == "d2c7d3761b73405ee39da3fd7fe5030dee35a39e");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Issue 8573 - A simpler Phobos function that returns the index of the …\n"~
                    "merged-on-behalf-of: Ilya Yaroshenko <testmail@example.com>");
@@ -75,7 +74,6 @@ unittest
         "/github/users/9il",
         "/github/repos/dlang/phobos/pulls/4921/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res) {
-            assert(req.json["sha"] == "d2c7d3761b73405ee39da3fd7fe5030dee35a39e");
             assert(req.json["merge_method"] == "squash");
             assert(req.json["commit_message"] == "Issue 8573 - A simpler Phobos function that returns the index of the …\n"~
                    "merged-on-behalf-of: Ilya Yaroshenko <testmail@example.com>");
@@ -108,7 +106,6 @@ unittest
         "/github/repos/dlang/phobos/pulls/4921/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res) {
             // https://developer.github.com/v3/pulls/#response-if-merge-cannot-be-performed
-            assert(req.json["sha"] == "d2c7d3761b73405ee39da3fd7fe5030dee35a39e");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Issue 8573 - A simpler Phobos function that returns the index of the …\n"~
                    "merged-on-behalf-of: Ilya Yaroshenko <testmail@example.com>");
@@ -178,7 +175,6 @@ unittest
         "/github/users/wilzbach",
         "/github/repos/vibe-d/vibe-core/pulls/22/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res) {
-            assert(req.json["sha"] == "04b3575c14dc7ad9971e19f153f3e3d712c1bdde");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Remove deprecated stdc import\n" ~
                     "merged-on-behalf-of: Sebastian Wilzbach <wilzbach@users.noreply.github.com>");
@@ -201,7 +197,6 @@ unittest
         "/github/users/wilzbach",
         "/github/repos/dlang-tour/core/pulls/583/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res) {
-            assert(req.json["sha"] == "4941624d1af77e84565ec86979c21c1d582b1c06");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Run docker update async + remove previous versions\n" ~
                     "merged-on-behalf-of: Sebastian Wilzbach <wilzbach@users.noreply.github.com>");

--- a/test/review.d
+++ b/test/review.d
@@ -10,7 +10,6 @@ unittest
         "/github/repos/dlang/phobos/issues/5114/events",
         "/github/users/ZombineDev",
         "/github/repos/dlang/phobos/pulls/5114/merge", (scope HTTPServerRequest req, scope HTTPServerResponse res) {
-            assert(req.json["sha"] == "0fb66f092b897b55318509c6582008b3f912311a");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Fix tan returning -nan for inputs where abs(x) >= 2^63\n"~
                    "merged-on-behalf-of: ZombineDev <ZombineDev@users.noreply.github.com>");

--- a/test/status.d
+++ b/test/status.d
@@ -68,7 +68,6 @@ unittest
         "/github/repos/dlang/dmd/issues/6327/events",
         "/github/repos/dlang/dmd/pulls/6327/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            assert(req.json["sha"] == "782fd3fdd4a9c23e1307b4b963b443ed60517dfe");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Fix issue 16977 - bad debug info for function default arguments\n"~
                    "merged-on-behalf-of: unknown");
@@ -102,7 +101,6 @@ unittest
         "/github/users/MartinNowak",
         "/github/repos/dlang/dmd/pulls/6328/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            assert(req.json["sha"] == "d6fc98058b637f9a558206847e6d7057ab9fb3de");
             assert(req.json["merge_method"] == "squash");
             assert(req.json["commit_message"] == "taking address of local means it cannot be 'scope' later\n"~
                    "merged-on-behalf-of: Martin Nowak <somemail@example.org>");
@@ -132,7 +130,6 @@ unittest
         "/github/repos/dlang/dmd/issues/6327/events",
         "/github/repos/dlang/dmd/pulls/6327/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            assert(req.json["sha"] == "782fd3fdd4a9c23e1307b4b963b443ed60517dfe");
             assert(req.json["merge_method"] == "merge");
             assert(req.json["commit_message"] == "Fix issue 16977 - bad debug info for function default arguments\n"~
                    "merged-on-behalf-of: unknown");
@@ -146,7 +143,6 @@ unittest
         "/github/users/MartinNowak",
         "/github/repos/dlang/dmd/pulls/6328/merge",
         (scope HTTPServerRequest req, scope HTTPServerResponse res){
-            assert(req.json["sha"] == "d6fc98058b637f9a558206847e6d7057ab9fb3de");
             assert(req.json["merge_method"] == "squash");
             assert(req.json["commit_message"] == "taking address of local means it cannot be 'scope' later\n"~
                    "merged-on-behalf-of: Martin Nowak <somemail@example.org>");


### PR DESCRIPTION
This should fix https://github.com/dlang-bots/dlang-bot/issues/77
The problem is that we fetch the head sha explicitly from GitHub and then send it
to them in the `tryMerge` method.
I don't know why exactly it sometimes fails (DMD doesn't require reviews), but
fetching the SHA in a separate request just to immediately send it to the GH API
isn't really "safe" anyways and apparentely it also causes problems.