### PR TITLE
dlangbot.github: Show Digger test command in automatic message

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -101,6 +101,7 @@ If you don't have a [local development environment setup](https://wiki.dlang.org
 ```sh
 dub fetch digger
 dub run digger -- build \"%s + %s#%d\"
+dub run digger -- test
 ```
 ".format(pr.base.ref_, pr.base.repo.name, pr.number));
     }


### PR DESCRIPTION
The previous message only told users how to build their pull request, but not how to run the test suite.

There's a few relevant commands here:
- `checkout` just gets the source code + does any merges necessary.
- `build` gets the source code, builds it, then puts it in a directory ready to be added to `PATH` and used.
- `rebuild` just builds whatever's currently checked out.
- `test` runs the test suite of whatever's currently checked out.

`build` + `test` is probably the most useful combination, as it allows both running the test suite, and giving users a build that they can play around with (i.e. test it against their personal codebase).