### PR TITLE
Upgrade stdx.allocator to 2.77.2

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -9,7 +9,7 @@
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
 		"openssl": "1.1.6+1.0.1g",
-		"stdx-allocator": "2.77.0",
+		"stdx-allocator": "2.77.2",
 		"taggedalgebraic": "0.10.8",
 		"unit-threaded": "0.7.36",
 		"vibe-core": "1.4.0-alpha.1",


### PR DESCRIPTION
This is to ensure the Jenkins CI passes at https://github.com/dlang/phobos/pull/6515