### PR TITLE
Recognise `Merge:auto-merge` label & friends

### DIFF
--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -224,10 +224,7 @@ Json[] tryMerge(in ref PullRequest pr, GHMerge.MergeMethod method)
 
     auto events = ghGetRequest(pr.eventsURL).body[]
         .retro
-        .filter!(e => e["event"] == "labeled" && (
-                 e["label"]["name"] == labelName)
-              || e["label"]["name"] == mergeLabelName
-                 );
+        .filter!(e => e["event"] == "labeled" && e["label"]["name"].among(labelName, mergeLabelName));
 
     string author = "unknown";
     if (!events.empty)

--- a/source/dlangbot/github.d
+++ b/source/dlangbot/github.d
@@ -183,9 +183,9 @@ GHMerge.MergeMethod autoMergeMethod(GHLabel[] labels)
         auto labelNames = labels.map!(l => l.name);
         if (labelNames.canFind!(l => (l == "auto-merge" || l == "Merge:auto-merge")))
             return merge;
-        else if (labelNames.canFind!(l => (l == "auto-merge-squash" || || l == "Merge:auto-merge-squash")))
+        else if (labelNames.canFind!(l => (l == "auto-merge-squash" || l == "Merge:auto-merge-squash")))
             return squash;
-        else if (labelNames.canFind!(l => (l == "auto-merge-rebase" || || l == "Merge:auto-merge-rebase")))
+        else if (labelNames.canFind!(l => (l == "auto-merge-rebase" || l == "Merge:auto-merge-rebase")))
             return rebase;
         return none;
     }


### PR DESCRIPTION
With the change from Bugzilla to GitHub we will now have a lot more labels, and they are naturally categorised into groups like `OS:Windows`. 

The ones that the bot deals with need to be handled properly here. Sill to do `Blocked`.